### PR TITLE
Bump bootstrap from 3.0.0 to 3.4.1 in /Vidly

### DIFF
--- a/Vidly/packages.config
+++ b/Vidly/packages.config
@@ -3,7 +3,7 @@
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="AutoMapper" version="4.1.0" targetFramework="net45" />
   <package id="bootbox" version="4.3.0" targetFramework="net45" />
-  <package id="bootstrap" version="3.0.0" targetFramework="net45" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net45" />
   <package id="elmah" version="1.2.2" targetFramework="net45" />
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
   <package id="EntityFramework" version="6.1.1" targetFramework="net45" />


### PR DESCRIPTION
Bumps bootstrap from 3.0.0 to 3.4.1.

Signed-off-by: dependabot[bot] <support@github.com>